### PR TITLE
Only require pyOpenSSL when generate_keys is true.

### DIFF
--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -6,6 +6,7 @@
   become: true
   with_items:
     - 'pyOpenSSL'
+  when: haproxy_load_balancer_ssl['generate_keys']
 
 - name: ssl | Ensuring SSL Keys Folders Exist
   file:


### PR DESCRIPTION
pyOpenSSL is only needed when generate_keys is true.
If you supply a pre existing key (via a separate template task from a ansible vault) then the pyopenssl module is not needed but currently installed regardless.