### PR TITLE
Allow to set file permission on haproxy.log file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -191,3 +191,7 @@ haproxy_syslog_servers:
   #   port: 514
 
 haproxy_version: 2.0
+
+# permission for file haproxy.log written by rsyslog
+# must be quoted
+haproxy_log_file_perms: '0640'

--- a/templates/etc/rsyslog.d/49-haproxy.conf.j2
+++ b/templates/etc/rsyslog.d/49-haproxy.conf.j2
@@ -3,6 +3,8 @@
 # /dev/log to chroot'ed HAProxy processes
 $AddUnixListenSocket /var/lib/haproxy/dev/log
 
+$FileCreateMode {{ haproxy_log_file_perms }}
+
 # Send HAProxy messages to a dedicated logfile
 {% if (haproxy_enable_remote_syslog is defined and not haproxy_enable_remote_syslog) or haproxy_enable_remote_syslog is not defined %}
 if $programname startswith 'haproxy' then /var/log/haproxy.log


### PR DESCRIPTION
## Description
The patch allows to define the permissions when rsyslog writes the log file.
I use it on a copy of the repo for years and forgot to submit it.

## Related Issue
need to allow other tooling to read the file (ex: `promtail`)
perhaps that would be better to set permissions to `0600`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly. (I did not find a documentation file to update)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 
